### PR TITLE
Remove extraneous f-string usage in pdfmaker

### DIFF
--- a/PDFMAKER/pdfmaker.py
+++ b/PDFMAKER/pdfmaker.py
@@ -107,7 +107,7 @@ def MkPDF(name: str):
                 )
             )
             pdf.build([table])
-            print(f"PDF criado com sucesso")
+            print("PDF criado com sucesso")
 
         else:
             half = images[:8]
@@ -135,7 +135,7 @@ def MkPDF(name: str):
                 )
             )
             pdf.build([table, table2])
-            print(f"PDF criado com sucesso")
+            print("PDF criado com sucesso")
     import shutil
     from pathlib import Path
     #set for main.py directory relative path with .


### PR DESCRIPTION
## Summary
- remove unneeded f-string markers in PDFMAKER/pdfmaker.py
- ensure the module ends with a newline

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684066820e908322ba3bbb16cc905721