### PR TITLE
Fix SR2DATA execution behavior

### DIFF
--- a/SR/SR2DATA.py
+++ b/SR/SR2DATA.py
@@ -238,11 +238,12 @@ def save_to_txt_report(name, measurements) -> None:
     print(f"Total de {len(measurements)} medidas foram salvas em report.txt.")
 
 
-print(pydicom.dcmread("SR.dcm").get_item((0x0040, 0xA121)))
-ds = pydicom.dcmread("SR.dcm").ContentSequence
-measurements, biometrical_data = ExtractSR(ds)
-print(measurements)
-biometrical_data = extract_biometrical_data(biometrical_data)
+if __name__ == "__main__":
+    print(pydicom.dcmread("SR.dcm").get_item((0x0040, 0xA121)))
+    ds = pydicom.dcmread("SR.dcm").ContentSequence
+    measurements, biometrical_data = ExtractSR(ds)
+    print(measurements)
+    biometrical_data = extract_biometrical_data(biometrical_data)
 
-plot_biometrical_data(biometrical_data)
-pdf_report("report", measurements, biometrical_data)
+    plot_biometrical_data(biometrical_data)
+    pdf_report("report", measurements, biometrical_data)


### PR DESCRIPTION
## Summary
- avoid running SR2DATA test code on import by wrapping it in `if __name__ == "__main__"`.

## Testing
- `python -m py_compile SR/SR2DATA.py`


------
https://chatgpt.com/codex/tasks/task_e_68406681290c8322929c383ce2705a77