### PR TITLE
Add expandable study list UI

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,6 +1,4 @@
 import StudyList from './components/StudyList/StudyList'
-import DicomViewer from './components/DicomViewer/DicomViewer'
-import MedicalReportView from './components/MedicalReport/MedicalReport'
 import type { Study, MedicalReport } from './types/dicom.types'
 
 const mockStudies: Study[] = [
@@ -31,10 +29,8 @@ const mockReport: MedicalReport = {
 
 function App() {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 text-white bg-gray-800 min-h-screen">
-      <StudyList studies={mockStudies} />
-      <DicomViewer />
-      <MedicalReportView report={mockReport} />
+    <div className="p-4 text-white bg-gray-800 min-h-screen">
+      <StudyList studies={mockStudies} report={mockReport} />
     </div>
   )
 }

--- a/webapp/src/components/PdfPreview/PdfPreview.tsx
+++ b/webapp/src/components/PdfPreview/PdfPreview.tsx
@@ -1,0 +1,7 @@
+export default function PdfPreview() {
+  return (
+    <div className="p-4 border border-gray-700 rounded-md">
+      <p className="text-gray-400">Visualização do PDF (placeholder)</p>
+    </div>
+  )
+}

--- a/webapp/src/components/StudyList/StudyList.tsx
+++ b/webapp/src/components/StudyList/StudyList.tsx
@@ -1,18 +1,39 @@
-import type { Study } from '../../types/dicom.types'
+import { useState } from 'react'
+import type { Study, MedicalReport } from '../../types/dicom.types'
+import PdfPreview from '../PdfPreview/PdfPreview'
+import MedicalReportView from '../MedicalReport/MedicalReport'
 
 interface StudyListProps {
   studies: Study[]
+  report: MedicalReport
 }
+export default function StudyList({ studies, report }: StudyListProps) {
+  const [expanded, setExpanded] = useState<string | null>(null)
 
-export default function StudyList({ studies }: StudyListProps) {
+  const toggle = (uid: string) => {
+    setExpanded((prev) => (prev === uid ? null : uid))
+  }
+
   return (
     <div className="p-4">
       <h2 className="text-lg font-semibold mb-2">Estudos</h2>
       <ul className="divide-y divide-gray-700">
         {studies.map((study) => (
           <li key={study.studyInstanceUID} className="py-2">
-            <span className="font-mono text-sm mr-2">{study.patientId}</span>
-            {study.patientName} - {study.studyDate} - {study.modality}
+            <button
+              type="button"
+              className="w-full text-left"
+              onClick={() => toggle(study.studyInstanceUID)}
+            >
+              <span className="font-mono text-sm mr-2">{study.patientId}</span>
+              {study.patientName} - {study.studyDate} - {study.modality}
+            </button>
+            {expanded === study.studyInstanceUID && (
+              <div className="mt-2 grid grid-cols-1 md:grid-cols-2 gap-4">
+                <PdfPreview />
+                <MedicalReportView report={report} />
+              </div>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- track the expanded study item in StudyList
- embed MedicalReportView and new PdfPreview when expanded
- simplify App to only show the StudyList
- add placeholder PdfPreview component

## Testing
- `npm run lint --prefix webapp`
- `npm run build --prefix webapp`


------
https://chatgpt.com/codex/tasks/task_e_6855bf7ca2e4832292985c4725225782