### PR TITLE
Document Windows printing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ It combines image processing with advanced biometrical analysis to provide a com
 - numpy: For numerical operations
 - scipy: For interpolation in growth charts
 
+### Printing Support (Windows Only)
+
+The automatic printing feature relies on the `pywin32` library. Printing from
+`main.py` is therefore available only on Windows systems. Users on other
+platforms should generate the PDF and print it manually.
+
 ### Development Environment
 
 This repository includes an optional Conda configuration. To create the

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ reportlab
 opencv-python
 pytesseract
 pyorthanc
+pywin32


### PR DESCRIPTION
## Summary
- add pywin32 to requirements for printing
- note in README that printing requires Windows

## Testing
- `pytest -q`
- `flake8 .` *(fails: E501 line too long and other style issues)*

------
https://chatgpt.com/codex/tasks/task_e_6855bfcca7e88322a8ee23debd731f1c