### PR TITLE
Add basic module import tests

### DIFF
--- a/IMG2PDF.py
+++ b/IMG2PDF.py
@@ -77,7 +77,8 @@ def Make_PDF():
     pdf.output("imagens_organizadas.pdf")
 
 
-Make_PDF()
+if __name__ == "__main__":
+    Make_PDF()
 
 def create_percentile_plot(plots_data, output_plot):
     weeks = np.arange(20, 40, 2)  # Semanas de gestação

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+# Ensure project root is on sys.path so local modules can be imported
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+
+def test_imports():
+    import IMG2PDF
+    from DicomManager.DICOM import DICOM2JPEG
+    from DicomManager.unzip import Unzipper
+    from PDFMAKER.pdfmaker import MkPDF
+
+    assert callable(IMG2PDF.Make_PDF)
+    assert callable(DICOM2JPEG)
+    assert callable(Unzipper)
+    assert callable(MkPDF)
+


### PR DESCRIPTION
## Summary
- prevent side effects when importing `IMG2PDF`
- add `tests/test_imports.py` to ensure key modules import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bfd6f4c483228aa7022f45bf0739