### PR TITLE
Add __main__ guard for Make_PDF

### DIFF
--- a/IMG2PDF.py
+++ b/IMG2PDF.py
@@ -77,7 +77,8 @@ def Make_PDF():
     pdf.output("imagens_organizadas.pdf")
 
 
-Make_PDF()
+if __name__ == "__main__":
+    Make_PDF()
 
 def create_percentile_plot(plots_data, output_plot):
     weeks = np.arange(20, 40, 2)  # Semanas de gestação


### PR DESCRIPTION
## Summary
- ensure Make_PDF is only called when IMG2PDF.py is executed directly

## Testing
- `python -m py_compile IMG2PDF.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bf19d11883229fb801b5aa77f837