### PR TITLE
Fix ultrasound text import

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from DicomManager.DICOM import DICOM2JPEG
 from PDFMAKER.pdfmaker import MkPDF
 
 
-from extract_ultrasound_text import extract_ultrasound_text
+from utils.ocr import extract_ultrasound_text
 
 
 # Windows-specific imports - only available on Windows


### PR DESCRIPTION
## Summary
- point `main.py` to use `utils.ocr.extract_ultrasound_text`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'IMG2PDF')*

------
https://chatgpt.com/codex/tasks/task_e_685efaa9abb88322a7a0fc2f4eaa089e