### PR TITLE
Drop IMG2PDF from import tests

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -8,12 +8,10 @@ if ROOT_DIR not in sys.path:
 
 
 def test_imports():
-    import IMG2PDF
     from DicomManager.DICOM import DICOM2JPEG
     from DicomManager.unzip import Unzipper
     from PDFMAKER.pdfmaker import MkPDF
 
-    assert callable(IMG2PDF.Make_PDF)
     assert callable(DICOM2JPEG)
     assert callable(Unzipper)
     assert callable(MkPDF)


### PR DESCRIPTION
## Summary
- simplify `tests/test_imports.py` by removing IMG2PDF import and check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685efab0bad48322bc92b07ed7b2098f