### PR TITLE
Add missing numpy dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.10
   - pydicom
   - pillow
+  - numpy
   - reportlab
   - pip
   - pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pydicom
 Pillow
+numpy
 matplotlib
 reportlab
 opencv-python


### PR DESCRIPTION
## Summary
- include `numpy` in Python requirements and Conda environment file

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f03c2ff908322af6135a8e9db058e