### PR TITLE
Add OCR and GPT tests

### DIFF
--- a/tests/test_extract_ultrasound_text.py
+++ b/tests/test_extract_ultrasound_text.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import numpy as np
+import cv2
+from unittest import mock
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from utils.ocr import extract_ultrasound_text
+
+
+def test_import_extract_ultrasound_text():
+    assert callable(extract_ultrasound_text)
+
+
+def test_extract_parses_text(tmp_path):
+    img = np.full((10, 10), 255, dtype=np.uint8)
+    img_path = tmp_path / "img.png"
+    cv2.imwrite(str(img_path), img)
+    sample = "BPD: 45.0\nFL 23,5\nAC=120.0"
+    with mock.patch("pytesseract.image_to_string", return_value=sample):
+        _, findings = extract_ultrasound_text(str(img_path))
+    assert findings == {"BPD": 45.0, "FL": 23.5, "AC": 120.0}

--- a/tests/test_gpt_replacement.py
+++ b/tests/test_gpt_replacement.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from unittest import mock
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from utils.gpt import replace_text_with_gpt
+
+
+def test_gpt_replacement_called():
+    fake_client = mock.Mock()
+    fake_client.complete.return_value = "novo texto"
+    result = replace_text_with_gpt("texto", client=fake_client)
+    fake_client.complete.assert_called_once_with("texto")
+    assert result == "novo texto"


### PR DESCRIPTION
## Summary
- add OCR parsing tests
- add GPT replacement test placeholder

## Testing
- `pip install numpy opencv-python-headless pytesseract`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.gpt')*

------
https://chatgpt.com/codex/tasks/task_e_685f006ab18c8322a8c6e1648bdc6c5e